### PR TITLE
Implement affinetransformable for scale and translate

### DIFF
--- a/arcs/src/algorithms/scale.rs
+++ b/arcs/src/algorithms/scale.rs
@@ -1,6 +1,7 @@
 use crate::{
     primitives::{Arc},
     algorithms::ScaleNonUniform,
+    components::{BoundingBox},
 };
 
 /// Something which can be scaled in *Drawing Space*
@@ -38,12 +39,22 @@ impl Scale for Arc {
     }
 }
 
+impl Scale for BoundingBox {
+    fn scale(&mut self, scale_factor: f64) {
+        *self = BoundingBox::new(
+            self.bottom_left().scaled(scale_factor),
+            self.top_right().scaled(scale_factor)
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::primitives::{Arc, Line};
     use crate::Vector;
     use crate::algorithms::{AffineTransformable, Translate};
+    use crate::components::{BoundingBox};
     use kurbo::Affine;
 
     #[test]
@@ -133,5 +144,18 @@ mod tests {
         transformed.translate(centre);
 
         assert_eq!(transformed, expected);
+    }
+
+    #[test]
+    fn scale_bounding_box() {
+        let first = Vector::new(-2.0, 1.5);
+        let second = Vector::new(4.0, 3.5);
+        let scale_factor = 1.5;
+        let original = BoundingBox::new(first, second);
+
+        let expected = BoundingBox::new(Vector::new(-3.0, 2.25), Vector::new(6.0, 5.25));
+        let actual = original.scaled(scale_factor);
+
+        assert_eq!(actual, expected);
     }
 }

--- a/arcs/src/algorithms/scale.rs
+++ b/arcs/src/algorithms/scale.rs
@@ -37,15 +37,6 @@ impl Scale for Arc {
     }
 }
 
-impl Scale for BoundingBox {
-    fn scale(&mut self, scale_factor: f64) {
-        *self = BoundingBox::new(
-            self.bottom_left().scaled(scale_factor),
-            self.top_right().scaled(scale_factor)
-        );
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/arcs/src/algorithms/scale.rs
+++ b/arcs/src/algorithms/scale.rs
@@ -28,10 +28,8 @@ impl<S: ScaleNonUniform> Scale for S {
 
 impl Scale for Arc {
     fn scale(&mut self, scale_factor: f64) {
-        let mut centre = self.centre();
-        centre.scale(scale_factor);
         *self = Arc::from_centre_radius(
-            centre, 
+            self.centre().scaled(scale_factor), 
             self.radius() * scale_factor, 
             self.start_angle(), 
             self.sweep_angle(),

--- a/arcs/src/algorithms/scale_non_uniform.rs
+++ b/arcs/src/algorithms/scale_non_uniform.rs
@@ -1,5 +1,6 @@
 use crate::{
     algorithms::{AffineTransformable},
+    components::{BoundingBox},
 };
 use kurbo::Affine;
 
@@ -23,6 +24,15 @@ impl<A: AffineTransformable> ScaleNonUniform for A {
     fn scale_non_uniform(&mut self, factor_x: f64, factor_y: f64){
         // TODO: Change to `Affine::scale_non_uniform()` after crates.io update
         self.transform(Affine::new([factor_x, 0.0, 0.0, factor_y, 0.0, 0.0]));
+    }
+}
+
+impl ScaleNonUniform for BoundingBox {
+    fn scale_non_uniform(&mut self, factor_x: f64, factor_y: f64) {
+        *self = BoundingBox::new(
+            self.bottom_left().scaled_non_uniform(factor_x, factor_y),
+            self.top_right().scaled_non_uniform(factor_x, factor_y)
+        );
     }
 }
 

--- a/arcs/src/algorithms/translate.rs
+++ b/arcs/src/algorithms/translate.rs
@@ -1,7 +1,9 @@
 use crate::{
-    primitives::{Arc, Line, Point},
+    primitives::{Arc},
     Vector,
+    algorithms::{AffineTransformable},
 };
+use kurbo::Affine;
 
 /// Something which can be moved around "rigidly" in *Drawing Space*.
 pub trait Translate {
@@ -18,33 +20,16 @@ pub trait Translate {
     }
 }
 
-impl<'t, T: Translate + ?Sized> Translate for &'t mut T {
+impl<A: AffineTransformable> Translate for A {
     fn translate(&mut self, displacement: Vector) {
-        (*self).translate(displacement);
-    }
-}
-
-impl Translate for Vector {
-    fn translate(&mut self, displacement: Vector) { *self += displacement; }
-}
-
-impl Translate for Point {
-    fn translate(&mut self, displacement: Vector) {
-        self.location += displacement;
-    }
-}
-
-impl Translate for Line {
-    fn translate(&mut self, displacement: Vector) {
-        self.start += displacement;
-        self.end += displacement;
+        self.transform(Affine::translate(displacement));
     }
 }
 
 impl Translate for Arc {
     fn translate(&mut self, displacement: Vector) {
         *self = Arc::from_centre_radius(
-            self.centre() + displacement,
+            self.centre().translated(displacement),
             self.radius(),
             self.start_angle(),
             self.sweep_angle(),
@@ -57,7 +42,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn vector() {
+    fn translate_vector() {
         let original = Vector::new(3.0, 4.0);
         let delta = Vector::new(-5.0, 2.5);
 

--- a/arcs/src/algorithms/translate.rs
+++ b/arcs/src/algorithms/translate.rs
@@ -2,6 +2,7 @@ use crate::{
     primitives::{Arc},
     Vector,
     algorithms::{AffineTransformable},
+    components::{BoundingBox},
 };
 use kurbo::Affine;
 
@@ -37,6 +38,15 @@ impl Translate for Arc {
     }
 }
 
+impl Translate for BoundingBox {
+    fn translate(&mut self, displacement: Vector) {
+        *self = BoundingBox::new_unchecked(
+            self.bottom_left().translated(displacement),
+            self.top_right().translated(displacement)
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -49,5 +59,18 @@ mod tests {
         let got = original.translated(delta);
 
         assert_eq!(got, original + delta);
+    }
+
+    #[test]
+    fn translate_bounding_box() {
+        let first = Vector::new(-2.0, 1.5);
+        let second = Vector::new(4.0, 3.7);
+        let displacement = Vector::new(1.0, -1.0);
+        let original = BoundingBox::new(first, second);
+
+        let expected = BoundingBox::new(Vector::new(-2.0 + 1.0, 1.5 + -1.0), Vector::new(4.0 + 1.0, 3.7 + -1.0));
+        let actual = original.translated(displacement);
+
+        assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
I changed the implementation of `Scale` and `Translate` to use `AffineTransformable` equivalent to the last PR for `ScaleNonUniform`.

This PR also implements all possible transformation methods for `BoundingBox`