### PR TITLE
Change arc::contains_angle to cover more cases of sweep angle and input angle

### DIFF
--- a/arcs/src/primitives/arc.rs
+++ b/arcs/src/primitives/arc.rs
@@ -77,16 +77,16 @@ impl<S> Arc<S> {
     }
 
     pub fn contains_angle(self, angle: Angle) -> bool {
-        let start_angle = self.start_angle();
-        let end_angle = self.end_angle();
-
-        let (min, max) = if start_angle < end_angle {
-            (start_angle, end_angle)
+        let diff = angle.positive() - self.start_angle.positive();
+        if diff > Angle::zero() {
+            self.sweep_angle >= diff
+                || self.sweep_angle <= -(Angle::two_pi() - diff)
+        } else if diff < Angle::zero() {
+            self.sweep_angle <= diff
+                || self.sweep_angle >= (Angle::two_pi() + diff)
         } else {
-            (end_angle, start_angle)
-        };
-
-        (min <= angle) && (angle <= max)
+            true
+        }
     }
 
     pub fn is_minor_arc(&self) -> bool {

--- a/arcs/src/primitives/arc.rs
+++ b/arcs/src/primitives/arc.rs
@@ -165,6 +165,9 @@ mod tests {
     test_contains_angle!(inside_reverse_arc,
         Arc::from_centre_radius(Point::zero(), 1.0, Angle::frac_pi_4(), -Angle::frac_pi_4()),
         45.0 => true);
+    test_contains_angle!(inside_major_reverse_arc,
+        Arc::from_centre_radius(Point::zero(), 1.0, Angle::zero(), Angle::degrees(-270.)),
+        180.0 => true);
 
     #[test]
     fn arc_from_three_points() {


### PR DESCRIPTION
Hello, I wanted to check first if this type of PR was alright but couldn't find a good way to contact you.
I was looking over the code for nearest point and went down a rabbit hole ending in arc::contains_angle. I added a test that I think should pass but doesn't (perhaps a missunderstanding).

The fix looks at the difference between input and start angle an ensures the sweep angle covers this difference or its "complement".

