### PR TITLE
Update euclid to 0.22 and fix API breaking changes

### DIFF
--- a/arcs/Cargo.toml
+++ b/arcs/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "Michael-F-Bryan/arcs", branch = "master" }
 anyhow = "1"
 arcs-core = { path = "../core", features = ["ecs"] }
 cgmath = "0.17.0"
-euclid = "0.20"
+euclid = "0.22"
 kurbo = "0.6"
 lazy_static = "1"
 log = "0.4"

--- a/arcs/src/window/utils.rs
+++ b/arcs/src/window/utils.rs
@@ -24,7 +24,7 @@ pub fn transform_to_drawing_space(
 ) -> Transform2D<f64, CanvasSpace, DrawingSpace> {
     // See https://gamedev.stackexchange.com/a/51435
 
-    let drawing_units_per_pixel = viewport.pixels_per_drawing_unit.inv();
+    let drawing_units_per_pixel = viewport.pixels_per_drawing_unit.inverse();
 
     // calculate the new basis vectors
     let x_axis = Vector2D::new(1.0, 0.0);
@@ -41,7 +41,7 @@ pub fn transform_to_drawing_space(
     //   | y_basis.x  y_basis.y  0 |
     //   | origin.x   origin.y   1 |
 
-    Transform2D::from_row_arrays([
+    Transform2D::from_arrays([
         x_axis_basis.to_array(),
         y_axis_basis.to_array(),
         new_origin.to_array(),
@@ -118,11 +118,11 @@ mod tests {
         let (_, viewport, window) = known_example();
 
         assert_eq!(
-            transform_to_drawing_space(&viewport, window).to_row_major_array(),
+            transform_to_drawing_space(&viewport, window).to_array(),
             [0.25, 0.0, 0.0, -0.25, 200.0, 200.0]
         );
         assert_eq!(
-            transform_to_canvas_space(&viewport, window).to_row_major_array(),
+            transform_to_canvas_space(&viewport, window).to_array(),
             [4.0, 0.0, 0.0, -4.0, -800.0, 800.0]
         );
     }

--- a/arcs/src/window/window.rs
+++ b/arcs/src/window/window.rs
@@ -106,10 +106,13 @@ struct RenderSystem<'window, B> {
 
 impl<'window, B> RenderSystem<'window, B> {
     /// Calculate the area of the drawing displayed by the viewport.
-    fn viewport_dimensions(&self, viewport: &Viewport) -> BoundingBox<DrawingSpace> {
+    fn viewport_dimensions(
+        &self,
+        viewport: &Viewport,
+    ) -> BoundingBox<DrawingSpace> {
         let window_size = viewport
             .pixels_per_drawing_unit
-            .inv()
+            .inverse()
             .transform_size(self.window_size);
 
         BoundingBox::from_centre_and_size(viewport.centre, window_size)
@@ -133,7 +136,7 @@ impl<'window, B: RenderContext> RenderSystem<'window, B> {
                     styles,
                     viewport,
                 );
-            },
+            }
             Geometry::Line(ref line) => {
                 self.render_line(
                     ent,
@@ -142,7 +145,7 @@ impl<'window, B: RenderContext> RenderSystem<'window, B> {
                     styles,
                     viewport,
                 );
-            },
+            }
             _ => unimplemented!(),
         }
     }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-euclid = "0.20.11"
+euclid = "0.22"
 specs = { version = "0.16.1", optional = true }
 
 [features]

--- a/core/src/algorithms/affine_transform.rs
+++ b/core/src/algorithms/affine_transform.rs
@@ -18,9 +18,9 @@ use euclid::default::Transform2D;
 /// use euclid::{Transform2D, approxeq::ApproxEq};
 ///
 /// let point = Point::new(10.0, 10.0);
-/// let transform_matrix = Transform2D::create_translation(-1.0, 1.0) // move the point
-///     .post_rotate(Angle::degrees(180.0)) // then rotate 180 degrees
-///     .post_scale(-1.0, 1.0); // then flip about y-axis
+/// let transform_matrix = Transform2D::translation(-1.0, 1.0) // move the point
+///     .then_rotate(Angle::degrees(180.0)) // then rotate 180 degrees
+///     .then_scale(-1.0, 1.0); // then flip about y-axis
 ///
 /// let got = point.transformed(transform_matrix);
 ///
@@ -54,18 +54,18 @@ impl<'t, T: AffineTransformable + ?Sized> AffineTransformable for &'t mut T {
 
 impl<Space> AffineTransformable for euclid::Vector2D<f64, Space> {
     fn transform(&mut self, transform: Transform2D<f64>) {
-        *self = transform
-            .pre_transform(&euclid::Transform2D::<f64, Space, _>::identity())
-            .post_transform(&euclid::Transform2D::<f64, _, Space>::identity())
+        *self = euclid::Transform2D::<f64, Space, _>::identity()
+            .then(&transform)
+            .then(&euclid::Transform2D::<f64, _, Space>::identity())
             .transform_vector(*self);
     }
 }
 
 impl<Space> AffineTransformable for euclid::Point2D<f64, Space> {
     fn transform(&mut self, transform: Transform2D<f64>) {
-        *self = transform
-            .pre_transform(&euclid::Transform2D::<f64, Space, _>::identity())
-            .post_transform(&euclid::Transform2D::<f64, _, Space>::identity())
+        *self = euclid::Transform2D::<f64, Space, _>::identity()
+            .then(&transform)
+            .then(&euclid::Transform2D::<f64, _, Space>::identity())
             .transform_point(*self);
     }
 }

--- a/core/src/algorithms/length.rs
+++ b/core/src/algorithms/length.rs
@@ -8,7 +8,9 @@ pub trait Length {
 }
 
 impl<'a, L: Length + ?Sized> Length for &'a L {
-    fn length(&self) -> f64 { (*self).length() }
+    fn length(&self) -> f64 {
+        (*self).length()
+    }
 }
 
 impl<Space> Length for Line<Space> {
@@ -21,7 +23,9 @@ impl<Space> Length for Line<Space> {
     ///
     /// assert_eq!(line.length(), 5.0);
     /// ```
-    fn length(&self) -> f64 { self.displacement().length() }
+    fn length(&self) -> f64 {
+        self.displacement().length()
+    }
 }
 
 impl<Space> Length for Vector2D<f64, Space> {
@@ -34,7 +38,9 @@ impl<Space> Length for Vector2D<f64, Space> {
     ///
     /// assert_eq!(vector.length(), 5.0);
     /// ```
-    fn length(&self) -> f64 { euclid::Vector2D::length(self) }
+    fn length(&self) -> f64 {
+        euclid::Vector2D::length(*self)
+    }
 }
 
 impl<Space> Length for Arc<Space> {
@@ -54,7 +60,9 @@ impl<Space> Length for Arc<Space> {
     ///
     /// assert_eq!(arc.length(), 2.0 * radius * PI);
     /// ```
-    fn length(&self) -> f64 { self.radius() * self.sweep_angle().radians.abs() }
+    fn length(&self) -> f64 {
+        self.radius() * self.sweep_angle().radians.abs()
+    }
 }
 
 #[cfg(test)]

--- a/core/src/algorithms/scale.rs
+++ b/core/src/algorithms/scale.rs
@@ -93,9 +93,9 @@ mod tests {
         // method: keep in mind that transforms get composed *in reverse
         // execution order*
         let combined_transform =
-            Transform::create_translation(-mid_point.x, -mid_point.y)
-                .post_scale(scale_factor, scale_factor)
-                .post_translate(mid_point);
+            Transform::translation(-mid_point.x, -mid_point.y)
+                .then_scale(scale_factor, scale_factor)
+                .then_translate(mid_point);
 
         let transformed = original.transformed(combined_transform);
 

--- a/core/src/algorithms/scale_non_uniform.rs
+++ b/core/src/algorithms/scale_non_uniform.rs
@@ -35,7 +35,7 @@ pub trait ScaleNonUniform {
 
 impl<A: AffineTransformable> ScaleNonUniform for A {
     fn scale_non_uniform(&mut self, factor_x: f64, factor_y: f64) {
-        self.transform(Transform2D::create_scale(factor_x, factor_y));
+        self.transform(Transform2D::scale(factor_x, factor_y));
     }
 }
 
@@ -90,10 +90,9 @@ mod tests {
         // Or compose an `Affine` and pass it directly to the `transform`
         // method: keep in mind that transforms get composed *in reverse
         // execution order*
-        let combined_transform =
-            Transform2D::create_translation(-base.x, -base.y)
-                .post_scale(factor_x, factor_y)
-                .post_translate(base);
+        let combined_transform = Transform2D::translation(-base.x, -base.y)
+            .then_scale(factor_x, factor_y)
+            .then_translate(base);
 
         let transformed = original.transformed(combined_transform);
 

--- a/core/src/algorithms/translate.rs
+++ b/core/src/algorithms/translate.rs
@@ -20,7 +20,7 @@ pub trait Translate<Space> {
 
 impl<Space, A: AffineTransformable> Translate<Space> for A {
     fn translate(&mut self, displacement: Vector2D<f64, Space>) {
-        self.transform(Transform2D::create_translation(
+        self.transform(Transform2D::translation(
             displacement.x,
             displacement.y,
         ));

--- a/core/src/bounding_box.rs
+++ b/core/src/bounding_box.rs
@@ -58,12 +58,12 @@ impl<S> BoundingBox<S> {
     ) -> Self {
         debug_assert!(
             width >= Length::zero(),
-            "{} should not be negative",
+            "{:?} should not be negative",
             width
         );
         debug_assert!(
             height >= Length::zero(),
-            "{} should not be negative",
+            "{:?} should not be negative",
             height
         );
 
@@ -74,10 +74,14 @@ impl<S> BoundingBox<S> {
     }
 
     /// How wide is the [`BoundingBox`] in the X direction.
-    pub fn width(self) -> Length<f64, S> { Length::new(self.diagonal().x) }
+    pub fn width(self) -> Length<f64, S> {
+        Length::new(self.diagonal().x)
+    }
 
     /// How high is the [`BoundingBox`] in the Y direction.
-    pub fn height(self) -> Length<f64, S> { Length::new(self.diagonal().y) }
+    pub fn height(self) -> Length<f64, S> {
+        Length::new(self.diagonal().y)
+    }
 
     /// Calculate the box's area.
     pub fn area(self) -> f64 {
@@ -115,7 +119,9 @@ impl<S> BoundingBox<S> {
     }
 
     /// The bottom-left corner.
-    pub fn bottom_left(self) -> Point2D<f64, S> { self.bottom_left }
+    pub fn bottom_left(self) -> Point2D<f64, S> {
+        self.bottom_left
+    }
 
     /// The bottom-right corner.
     pub fn bottom_right(self) -> Point2D<f64, S> {
@@ -123,7 +129,9 @@ impl<S> BoundingBox<S> {
     }
 
     /// The top-right corner.
-    pub fn top_right(self) -> Point2D<f64, S> { self.top_right }
+    pub fn top_right(self) -> Point2D<f64, S> {
+        self.top_right
+    }
 
     /// The top-left corner.
     pub fn top_left(self) -> Point2D<f64, S> {
@@ -131,16 +139,24 @@ impl<S> BoundingBox<S> {
     }
 
     /// The minimum X value.
-    pub fn min_x(self) -> f64 { self.bottom_left.x }
+    pub fn min_x(self) -> f64 {
+        self.bottom_left.x
+    }
 
     /// The minimum Y value.
-    pub fn min_y(self) -> f64 { self.bottom_left.y }
+    pub fn min_y(self) -> f64 {
+        self.bottom_left.y
+    }
 
     /// The maximum X value.
-    pub fn max_x(self) -> f64 { self.top_right.x }
+    pub fn max_x(self) -> f64 {
+        self.top_right.x
+    }
 
     /// The maximum Y value.
-    pub fn max_y(self) -> f64 { self.top_right.y }
+    pub fn max_y(self) -> f64 {
+        self.top_right.y
+    }
 
     /// Does this [`BoundingBox`] fully contain another?
     pub fn fully_contains(self, other: BoundingBox<S>) -> bool {
@@ -159,7 +175,9 @@ impl<S> BoundingBox<S> {
 
 impl<Space> Copy for BoundingBox<Space> {}
 impl<Space> Clone for BoundingBox<Space> {
-    fn clone(&self) -> Self { *self }
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 
 #[cfg(feature = "ecs")]


### PR DESCRIPTION
This PR brings the `euclid` crate upto date and fixes some API breaking changes which happened between 0.20 -> 0.21